### PR TITLE
串口数据包大于255时会出错

### DIFF
--- a/component/bluetooth/src/core/bt_l2cap.c
+++ b/component/bluetooth/src/core/bt_l2cap.c
@@ -854,6 +854,12 @@ void l2cap_process_sig(struct bt_pbuf_t *q, struct l2cap_hdr_t *l2caphdr, struct
 					   now close the connection */
             break;
         case L2CAP_ECHO_REQ:
+
+        	 if(pcb == NULL)
+			{
+				/* A response without a matching request is silently discarded */
+				break;
+			}
             pcb->ursp_id = sighdr->id;
             ret = l2cap_signal(pcb, L2CAP_ECHO_RSP, sighdr->id, &(pcb->remote_bdaddr), NULL);
             break;

--- a/component/bluetooth/src/core/bt_pbuf.c
+++ b/component/bluetooth/src/core/bt_pbuf.c
@@ -303,7 +303,7 @@ static uint8_t pbuf_header_impl(struct bt_pbuf_t *p, int16_t header_size_increme
  * para        : p(IN)	--> 传入的pbuf
                  header_size_increment(IN)	--> payload偏移大小
                  buffer[4]={1,2,3,4}，架设payload位置在2,那么便宜-1，那么偏移
-                 位置的数据变为3，如果在此基础便宜2,那么payload变为1
+                 位置的数据变为3，如果在此基础偏移2,那么payload变为1
  * return      : 0成功，非0失败
  * description : 调整payload指针以隐藏或显示有效负载中的标头。
 ******************************************************************************/

--- a/component/bluetooth/src/core/classical/bt_rfcomm.c
+++ b/component/bluetooth/src/core/classical/bt_rfcomm.c
@@ -1071,7 +1071,7 @@ void rfcomm_process_msg(struct rfcomm_pcb_t *pcb, struct rfcomm_hdr_t *rfcommhdr
 
             tpcb->rfcommcfg |= RFCOMM_CFG_MSC_OUT;
 
-            if(tpcb->rfcommcfg & RFCOMM_CFG_MSC_IN && tpcb->state != RFCOMM_OPEN)
+            if((tpcb->rfcommcfg & RFCOMM_CFG_MSC_IN) && tpcb->state != RFCOMM_OPEN)
             {
                 tpcb->state = RFCOMM_OPEN;
                 if(tpcb->rfcommcfg & RFCOMM_CFG_IR)

--- a/component/bluetooth/src/core/classical/bt_spp.c
+++ b/component/bluetooth/src/core/classical/bt_spp.c
@@ -89,7 +89,7 @@ err_t spp_init(spp_cbs_t *cb)
     uint16_t spp_de_size = 0;
     uint32_t spp_record_hdl = sdp_next_rhdl();
 
-    BT_SPP_TRACE_DEBUG("spp_init: Allocate RFCOMM PCB for CN RFCOMM_SPP_SERVER_CHNL\n");
+    BT_SPP_TRACE_DEBUG("spp_init: Allocate RFCOMM PCB for CN %d\n", RFCOMM_SPP_SERVER_CHNL);
     if((rfcommpcb = rfcomm_new(NULL)) == NULL)
     {
         BT_SPP_TRACE_DEBUG("spp_init: Could not alloc RFCOMM PCB for channel RFCOMM_SPP_SERVER_CHNL\n");

--- a/project/ubuntu_csr8x11_bt/bt_phybusif_h4.c
+++ b/project/ubuntu_csr8x11_bt/bt_phybusif_h4.c
@@ -128,7 +128,7 @@ uint8_t hw_uart_bt_init(uint32_t baud_rate,uint8_t reconfig)
 }
 
 
-void uart_bt_send(uint8_t *buf,uint8_t len)
+void uart_bt_send(uint8_t *buf,uint16_t len)
 {
     write(uart_if.phyuart_fd,buf,len);
 }


### PR DESCRIPTION
【问题描述】:串口数据包大于255时会出错
【程序描述】:HCI命令中VS数据包最大255，加上HCI头会超过255字节
【修改内容】:
1.修改长度类型为uint16_t
【相关文件】:ubuntu_csr8x11_bt/bt_phybusif_h4.c
【需要测试】:是